### PR TITLE
Add backend argument to fix exception

### DIFF
--- a/padding_ora_cli
+++ b/padding_ora_cli
@@ -42,7 +42,7 @@ class PaddingOracleCLI():
 
 		self._invalid = 0
 		self._valid = 0
-		cipher = cryptography.hazmat.primitives.ciphers.Cipher(cryptography.hazmat.primitives.ciphers.algorithms.AES(self._key), cryptography.hazmat.primitives.ciphers.modes.ECB())
+		cipher = cryptography.hazmat.primitives.ciphers.Cipher(cryptography.hazmat.primitives.ciphers.algorithms.AES(self._key), cryptography.hazmat.primitives.ciphers.modes.ECB(), backend=cryptography.hazmat.backends.default_backend())
 		decryptor = cipher.decryptor()
 		ciphertext = bytes.fromhex(self._args.ciphertext)
 		self._plaintext = decryptor.update(ciphertext) + decryptor.finalize()


### PR DESCRIPTION
At least in two systems where I tested the project, I encountered a TypeError since there is missing one backend argument in the __init__ function. By adding the default_backend() as an argument to the Cipher constructor, this is fixed and the CLI tool works as expected.